### PR TITLE
Add vr_only metadata tag

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.makepad.rustquest">
+    <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
+
     <application android:label="rustquest">
         <activity android:name="MainActivity">
             <intent-filter>


### PR DESCRIPTION
This manifest tag is needed to get the APK to display under the "unknown sources" tab in the UI.

See https://developer.oculus.com/documentation/native/android/mobile-native-manifest/?device=QUEST for the full breakdown.